### PR TITLE
Implement granular recipe supply endpoints

### DIFF
--- a/Restock.Platform.API/Planning/Application/Internal/QueryServices/RecipeQueryService.cs
+++ b/Restock.Platform.API/Planning/Application/Internal/QueryServices/RecipeQueryService.cs
@@ -1,19 +1,25 @@
 ﻿using Restock.Platform.API.Planning.Domain.Model.Aggregates;
 using Restock.Platform.API.Planning.Domain.Repositories;
 using Restock.Platform.API.Planning.Domain.Services;
+using Restock.Platform.API.Planning.Domain.Model.Entities;
 
 namespace Restock.Platform.API.Planning.Application.Internal.QueryServices;
 
 public class RecipeQueryService(
     IRecipeRepository recipeRepository) : IRecipeQueryService
 {
-    public async Task<IEnumerable<Recipe>> ListAsync()
+    public async Task<IEnumerable<Recipe>> ListAsync(bool includeSupplies = false)
     {
-        return await recipeRepository.ListAsync();
+        return await recipeRepository.ListAsync(includeSupplies);
     }
 
-    public async Task<Recipe?> GetByIdAsync(Guid id)
+    public async Task<Recipe?> GetByIdAsync(Guid id, bool includeSupplies = false)
     {
-        return await recipeRepository.FindByIdAsync(id);
+        return await recipeRepository.FindByIdAsync(id, includeSupplies);
+    }
+
+    public async Task<IEnumerable<RecipeSupply>> ListSuppliesByRecipeIdAsync(Guid recipeId)
+    {
+        return await recipeRepository.ListSuppliesByRecipeIdAsync(recipeId);
     }
 }

--- a/Restock.Platform.API/Planning/Domain/Model/Commands/AddRecipeSupplyCommand.cs
+++ b/Restock.Platform.API/Planning/Domain/Model/Commands/AddRecipeSupplyCommand.cs
@@ -1,0 +1,3 @@
+namespace Restock.Platform.API.Planning.Domain.Model.Commands;
+
+public record AddRecipeSupplyCommand(Guid RecipeId, Guid SupplyId, double Quantity);

--- a/Restock.Platform.API/Planning/Domain/Model/Commands/DeleteRecipeSupplyCommand.cs
+++ b/Restock.Platform.API/Planning/Domain/Model/Commands/DeleteRecipeSupplyCommand.cs
@@ -1,0 +1,3 @@
+namespace Restock.Platform.API.Planning.Domain.Model.Commands;
+
+public record DeleteRecipeSupplyCommand(Guid RecipeId, Guid SupplyId);

--- a/Restock.Platform.API/Planning/Domain/Model/Commands/UpdateRecipeSupplyCommand.cs
+++ b/Restock.Platform.API/Planning/Domain/Model/Commands/UpdateRecipeSupplyCommand.cs
@@ -1,0 +1,3 @@
+namespace Restock.Platform.API.Planning.Domain.Model.Commands;
+
+public record UpdateRecipeSupplyCommand(Guid RecipeId, Guid SupplyId, double Quantity);

--- a/Restock.Platform.API/Planning/Domain/Repositories/IRecipeRepository.cs
+++ b/Restock.Platform.API/Planning/Domain/Repositories/IRecipeRepository.cs
@@ -1,11 +1,13 @@
 ﻿using Restock.Platform.API.Planning.Domain.Model.Aggregates;
+using Restock.Platform.API.Planning.Domain.Model.Entities;
 
 namespace Restock.Platform.API.Planning.Domain.Repositories;
 
 public interface IRecipeRepository
 {
-    Task<Recipe?> FindByIdAsync(Guid id);
-    Task<IEnumerable<Recipe>> ListAsync();
+    Task<Recipe?> FindByIdAsync(Guid id, bool includeSupplies = false);
+    Task<IEnumerable<Recipe>> ListAsync(bool includeSupplies = false);
+    Task<IEnumerable<RecipeSupply>> ListSuppliesByRecipeIdAsync(Guid recipeId);
     Task AddAsync(Recipe recipe);
     void Update(Recipe recipe);
     void Remove(Recipe recipe);

--- a/Restock.Platform.API/Planning/Domain/Services/IRecipeCommandService.cs
+++ b/Restock.Platform.API/Planning/Domain/Services/IRecipeCommandService.cs
@@ -8,4 +8,6 @@ public interface IRecipeCommandService
     Task Handle(UpdateRecipeCommand command);
     Task Handle(DeleteRecipeCommand command);
     Task Handle(AddRecipeSupplyCommand command);
+    Task Handle(UpdateRecipeSupplyCommand command);
+    Task Handle(DeleteRecipeSupplyCommand command);
 }

--- a/Restock.Platform.API/Planning/Domain/Services/IRecipeQueryService.cs
+++ b/Restock.Platform.API/Planning/Domain/Services/IRecipeQueryService.cs
@@ -1,9 +1,11 @@
 ﻿using Restock.Platform.API.Planning.Domain.Model.Aggregates;
+using Restock.Platform.API.Planning.Domain.Model.Entities;
 
 namespace Restock.Platform.API.Planning.Domain.Services;
 
 public interface IRecipeQueryService
 {
-    Task<IEnumerable<Recipe>> ListAsync();
-    Task<Recipe?> GetByIdAsync(Guid id);
+    Task<IEnumerable<Recipe>> ListAsync(bool includeSupplies = false);
+    Task<Recipe?> GetByIdAsync(Guid id, bool includeSupplies = false);
+    Task<IEnumerable<RecipeSupply>> ListSuppliesByRecipeIdAsync(Guid recipeId);
 }

--- a/Restock.Platform.API/Planning/Interfaces/REST/Resources/UpdateRecipeSupplyResource.cs
+++ b/Restock.Platform.API/Planning/Interfaces/REST/Resources/UpdateRecipeSupplyResource.cs
@@ -1,0 +1,3 @@
+namespace Restock.Platform.API.Planning.Interfaces.REST.Resources;
+
+public record UpdateRecipeSupplyResource(double Quantity);

--- a/Restock.Platform.API/Planning/Interfaces/REST/Transform/RecipeResourceFromEntityAssembler.cs
+++ b/Restock.Platform.API/Planning/Interfaces/REST/Transform/RecipeResourceFromEntityAssembler.cs
@@ -1,12 +1,20 @@
 ﻿using Restock.Platform.API.Planning.Domain.Model.Aggregates;
 using Restock.Platform.API.Planning.Interfaces.REST.Resources;
+using System.Collections.Generic;
 
 namespace Restock.Platform.API.Planning.Interfaces.REST.Transform;
 
 public static class RecipeResourceFromEntityAssembler
 {
-    public static RecipeResource ToResource(Recipe recipe)
+    public static RecipeResource ToResource(Recipe recipe, bool includeSupplies = false)
     {
+        var supplies = includeSupplies
+            ? recipe.Supplies.Select(s => new RecipeSupplyResource(
+                    s.SupplyId.Value,
+                    s.Quantity.Value
+                )).ToList()
+            : new List<RecipeSupplyResource>();
+
         return new RecipeResource(
             recipe.Id.Value,
             recipe.Name,
@@ -14,10 +22,7 @@ public static class RecipeResourceFromEntityAssembler
             recipe.ImageUrl.Value,
             recipe.TotalPrice.Value,
             recipe.UserId,
-            recipe.Supplies.Select(s => new RecipeSupplyResource(
-                s.SupplyId.Value,
-                s.Quantity.Value
-            )).ToList()
+            supplies
         );
     }
 }


### PR DESCRIPTION
## Summary
- support retrieving recipes with or without supplies
- add endpoints to fetch and manage recipe supplies
- implement commands and services for updating and deleting recipe supplies
- extend repositories and query services for optional supply inclusion

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fa0d1e14832da345a030c70efffa